### PR TITLE
kchat-mode.el: implement process filter for chats

### DIFF
--- a/kchat-mode.el
+++ b/kchat-mode.el
@@ -73,7 +73,8 @@
                (body (alist-get 'body text)))
           (save-excursion
             (set-buffer buffer)
-            (insert  (format "%s: %s" username body))
+            (goto-char (point-max))
+            (insert (format "%s: %s" username body))
             (newline))))))))
                         
 


### PR DESCRIPTION
kchat-json-filter-to: new function that returns a process filter which
listens for messages and puts them into a buffer corresponding to a
given chat

lexical-binding needs to be set because otherwise, we can't return a
lambda function which closes over the `buffer' parameter of
kchat-json-filter